### PR TITLE
DefaultClient stop method now sets started flag to false

### DIFF
--- a/bt-core/src/main/java/bt/DefaultClient.java
+++ b/bt-core/src/main/java/bt/DefaultClient.java
@@ -110,6 +110,7 @@ class DefaultClient<C extends ProcessingContext> implements BtClient {
             });
         } finally {
             future.ifPresent(future -> future.complete(null));
+            started = false;
         }
     }
 


### PR DESCRIPTION
Hi,

consider following:
...
client.stop();
client.isStarted(); // Returns true
After stopping client, I would expect client.isStarted() to return false.

This pull request fixes this issue by simply setting `started` flag to `false` in `stop()` method.

Cheers,
Bojan